### PR TITLE
fix condition for open tab in editor

### DIFF
--- a/src/modules/editor/event-handlers/open-tab.ts
+++ b/src/modules/editor/event-handlers/open-tab.ts
@@ -18,7 +18,7 @@ export const handleOpenTab: OrdoEventHandler<"@editor/open-tab"> = async ({
 	const tree = draft.fileExplorer.tree;
 	const file = findOrdoFile(tree, "path", payload);
 
-	if (currentTab === payload || !file) {
+	if (!file) {
 		return;
 	}
 


### PR DESCRIPTION
Поменял условие открытия таба в Editor. Это пофиксило проблему.
Проверил другие кнопки перехода в Editor - вроде ничего не сломало.

@orlowdev глянь, как у тебя время будет. Возможно, я какую-то особенность упускаю.

Closes #16 